### PR TITLE
Steam is Ready

### DIFF
--- a/lib/Errors/errors.js
+++ b/lib/Errors/errors.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.provider = exports.prefix = void 0;
 exports.prefix = 'Easy Auth Error:';
-exports.provider = ["Facebook", "Google", "GitHub", "Discord"];
+exports.provider = ["Facebook", "Google", "GitHub", "Discord", "Steam"];
 exports.default = {
     prefix: exports.prefix,
     provider: exports.provider

--- a/lib/Steam/steam.js
+++ b/lib/Steam/steam.js
@@ -1,1 +1,44 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.authUser = exports.redirectURL = void 0;
+const axios_1 = __importDefault(require("axios"));
+const wix_secret_helpers_1 = require("@exweiv/wix-secret-helpers");
+const querystring_1 = __importDefault(require("querystring"));
+const errors_1 = __importDefault(require("../Errors/errors"));
+const redirectURL = (options) => {
+    try {
+        const { realm, redirect_uri } = options;
+        const rootURL = "https://steamcommunity.com/openid/login";
+        const urlOptions = {
+            "openid.ns": "http://specs.openid.net/auth/2.0",
+            "openid.mode": "checkid_setup",
+            "openid.return_to": redirect_uri,
+            "openid.realm": realm,
+            "openid.identity": "http://specs.openid.net/auth/2.0/identifier_select",
+            "openid.claimed_id": "http://specs.openid.net/auth/2.0/identifier_select"
+        };
+        return `${rootURL}?${querystring_1.default.stringify(urlOptions)}`;
+    }
+    catch (err) {
+        throw Error(`${errors_1.default.prefix} ${errors_1.default.provider[4]} - ${err}`);
+    }
+};
+exports.redirectURL = redirectURL;
+const authUser = async (options, client_secret) => {
+    try {
+        const { steamId } = options;
+        const steamUserResponse = await axios_1.default.get(`https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=${!client_secret ? await (0, wix_secret_helpers_1.getSecretValue)("SteamClientSecret") : client_secret}&steamids=${steamId}`);
+        const result = steamUserResponse.data;
+        if (!(result && result.response && Array.isArray(result.response.players) && result.response.players.length > 0)) {
+            throw new Error(`Malformed response while retrieving user's Steam profile information`);
+        }
+        return result.response.players[0];
+    }
+    catch (err) {
+        throw Error(`${errors_1.default.prefix} ${errors_1.default.provider[4]} - ${err}`);
+    }
+};
+exports.authUser = authUser;

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,8 +23,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.github = exports.discord = exports.facebook = exports.google = void 0;
+exports.steam = exports.github = exports.discord = exports.facebook = exports.google = void 0;
 exports.google = __importStar(require("./Google/google"));
 exports.facebook = __importStar(require("./Facebook/facebook"));
 exports.discord = __importStar(require("./Discord/discord"));
 exports.github = __importStar(require("./GitHub/github"));
+exports.steam = __importStar(require("./Steam/steam"));

--- a/src/Errors/errors.ts
+++ b/src/Errors/errors.ts
@@ -1,5 +1,5 @@
 export const prefix = 'Easy Auth Error:';
-export const provider = ["Facebook", "Google", "GitHub", "Discord"];
+export const provider = ["Facebook", "Google", "GitHub", "Discord", "Steam"];
 
 export default {
     prefix,

--- a/src/Steam/steam.ts
+++ b/src/Steam/steam.ts
@@ -1,0 +1,50 @@
+/// <reference path="../../types/index.d.ts" />
+
+// Type Imports
+import type { Steam, AuthResponse } from '@exweiv/easy-auth';
+// API Imports
+import axios from 'axios';
+import { getSecretValue } from '@exweiv/wix-secret-helpers';
+import querystring from 'querystring';
+// Internal Imports
+import errCodes from '../Errors/errors';
+
+export const redirectURL = (options: Steam.RedirectURLOptions): string => {
+    try {
+        const {
+            realm,
+            redirect_uri
+        } = options;
+
+        const rootURL = "https://steamcommunity.com/openid/login";
+        const urlOptions = {
+            "openid.ns": "http://specs.openid.net/auth/2.0",
+            "openid.mode": "checkid_setup",
+            "openid.return_to": redirect_uri,
+            "openid.realm": realm,
+            "openid.identity": "http://specs.openid.net/auth/2.0/identifier_select",
+            "openid.claimed_id": "http://specs.openid.net/auth/2.0/identifier_select"
+        }
+
+        return `${rootURL}?${querystring.stringify(urlOptions)}`;
+    } catch (err) {
+        throw Error(`${errCodes.prefix} ${errCodes.provider[4]} - ${err}`);
+    }
+}
+
+export const authUser = async (options: Steam.AuthOptions, client_secret?: string): Promise<AuthResponse> => {
+    try {
+        const { steamId } = options;
+
+        const steamUserResponse = await axios.get(`https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=${!client_secret ? await getSecretValue("SteamClientSecret") : client_secret}&steamids=${steamId}`)
+        const result = steamUserResponse.data;
+
+        if (!(result && result.response && Array.isArray(result.response.players) && result.response.players.length > 0)) {
+            throw new Error(`Malformed response while retrieving user's Steam profile information`);
+        }
+
+        return result.response.players[0];
+    } catch (err) {
+        throw Error(`${errCodes.prefix} ${errCodes.provider[4]} - ${err}`);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * as google from './Google/google';
 export * as facebook from './Facebook/facebook';
 export * as discord from './Discord/discord';
 export * as github from './GitHub/github';
+export * as steam from './Steam/steam';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -256,4 +256,38 @@ declare module '@exweiv/easy-auth' {
          */
         getTokens(options: Discord.TokensOptions): Promise<Discord.TokensResponse>;
     }
+
+    namespace Steam {
+        type RedirectURLOptions = {
+            realm: string,
+            redirect_uri: string,
+            state?: string
+        }
+
+        type AuthOptions = {
+            steamId: string
+        }
+    }
+
+    /**
+     * Steam itself doesn't provide any OAuth 2.0 or something similar to authenticate users with their APIs. You'll need to implement a secure way to authenticate users via Steam.
+     * This isn't a realy OAuth 2.0 method since you won't get any access_token after user sign-in to Steam, what you'll get is users's public Steam ID (number).
+     * That you can use to get public info of that user after successful login.
+     */
+    interface steam {
+        /**
+         * Creates a redirect url for authenticating user via Steam
+         * 
+         * @param options Options that's used when creating redirect url.
+         */
+        redirectURL(options: Steam.RedirectURLOptions): string;
+
+        /**
+         * Gets user data from Steam
+         * 
+         * @param options Options that's used when getting user data from Steam.
+         * @param client_secret Defaults to undefined, if you don't pass a client_secret (apiKey) API will use Wix Secret Manager to find client_secret named as `SteamClientSecret`.
+         */
+        userAuth(options: Steam.AuthOptions, client_secret?: string): Promise<AuthResponse>;
+    }
 }


### PR DESCRIPTION
Steam is ready as an oauth option with a different way since oauth 2.0 is not possible with Steam's own web apis anymore. We used openid system to at least authenticate users with a stateless option, which will bring security issues to be fixed in implementation.